### PR TITLE
Update beignet SRCREV to latest HEAD

### DIFF
--- a/meta-ostro-xt/recipes-opencl/beignet/beignet/0001-Add-support-for-more-Broxton-PCI-IDs.patch
+++ b/meta-ostro-xt/recipes-opencl/beignet/beignet/0001-Add-support-for-more-Broxton-PCI-IDs.patch
@@ -1,27 +1,30 @@
-From 9d27b530498560376a4ef3aef5214cbc21c36c05 Mon Sep 17 00:00:00 2001
-From: Ross Burton <ross.burton@intel.com>
-Date: Tue, 7 Jun 2016 15:13:59 +0100
+From 09e20afa2740d35af5fb3dfda8a95567c59f2a8c Mon Sep 17 00:00:00 2001
+From: Jussi Laako <jussi.laako@linux.intel.com>
+Date: Mon, 15 Aug 2016 16:57:29 +0300
 Subject: [PATCH] Add support for more Broxton PCI IDs
 
 Upstream-Status: Inappropriate [the added IDs are not public]
 
+Author: Ross Burton <ross.burton@intel.com>
 ---
- src/cl_device_data.h | 17 ++++++++++++-----
- src/cl_device_id.c   |  6 +++++-
- 2 files changed, 17 insertions(+), 6 deletions(-)
+ src/cl_device_data.h | 19 ++++++++++++-------
+ src/cl_device_id.c   |  6 ++++++
+ 2 files changed, 18 insertions(+), 7 deletions(-)
 
 diff --git a/src/cl_device_data.h b/src/cl_device_data.h
-index f789feb..92321e1 100644
+index 30366ea..4076046 100644
 --- a/src/cl_device_data.h
 +++ b/src/cl_device_data.h
-@@ -297,12 +297,19 @@
+@@ -297,12 +297,18 @@
  #define IS_SKYLAKE(devid) (IS_SKL_GT1(devid) || IS_SKL_GT2(devid) || IS_SKL_GT3(devid) || IS_SKL_GT4(devid))
  
  /* BXT */
 -#define PCI_CHIP_BROXTON_P	0x5A84   /* Intel(R) BXT-P for mobile desktop */
+-#define PCI_CHIP_BROXTON_1	0x5A85
 -
 -#define IS_BROXTON(devid)               \
--  (devid == PCI_CHIP_BROXTON_P)
+-  (devid == PCI_CHIP_BROXTON_P ||       \
+-   devid == PCI_CHIP_BROXTON_1)
 +#define PCI_CHIP_BROXTON_0  0x0A84
 +#define PCI_CHIP_BROXTON_1  0x1A84
 +#define PCI_CHIP_BROXTON_P  0x5A84   /* Intel(R) BXT-P for mobile desktop */
@@ -35,31 +38,30 @@ index f789feb..92321e1 100644
 +   devid == PCI_CHIP_BROXTON_2 || \
 +   devid == PCI_CHIP_BROXTON_3)
  
- #define IS_GEN9(devid)      (IS_SKYLAKE(devid) || IS_BROXTON(devid))
+ #define PCI_CHIP_KABYLAKE_ULT_GT1     0x5906
+ #define PCI_CHIP_KABYLAKE_ULT_GT2     0x5916
+@@ -360,4 +366,3 @@
+ #define IS_GEN9(devid)     (IS_SKYLAKE(devid) || IS_BROXTON(devid) || IS_KABYLAKE(devid))
  
  #endif /* __CL_DEVICE_DATA_H__ */
 -
 diff --git a/src/cl_device_id.c b/src/cl_device_id.c
-index 00d014b..56f68e9 100644
+index df3355c..aacc9f9 100644
 --- a/src/cl_device_id.c
 +++ b/src/cl_device_id.c
-@@ -569,6 +569,11 @@ skl_gt4_break:
+@@ -615,6 +615,12 @@ skl_gt4_break:
        cl_intel_platform_enable_extension(ret, cl_khr_fp16_ext_id);
        break;
  
 +    case PCI_CHIP_BROXTON_0:
 +    case PCI_CHIP_BROXTON_1:
++    case PCI_CHIP_BROXTON_P:
 +    case PCI_CHIP_BROXTON_2:
 +    case PCI_CHIP_BROXTON_3:
 +      DECL_INFO_STRING(bxt_break, intel_bxt_device, name, "Intel(R) HD Graphics Broxton");
      case PCI_CHIP_BROXTON_P:
        DECL_INFO_STRING(bxt_break, intel_bxt_device, name, "Intel(R) HD Graphics Broxton-P");
  bxt_break:
-@@ -1087,4 +1092,3 @@ cl_get_kernel_workgroup_info(cl_kernel kernel,
- error:
-   return err;
- }
--
 -- 
-2.8.0.rc3
+2.9.3
 

--- a/meta-ostro-xt/recipes-opencl/beignet/beignet/reduced-native.patch
+++ b/meta-ostro-xt/recipes-opencl/beignet/beignet/reduced-native.patch
@@ -1,8 +1,14 @@
+commit 9f421841f71b58811a6b98c4e7e655581eaf5d89
+Author: Jussi Laako <jussi.laako@linux.intel.com>
+Date:   Mon Aug 15 17:07:23 2016 +0300
+
+    Reduced native
+
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0af63c1..bb3bb74 100644
+index d839f3f..72b2431 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -120,78 +120,9 @@ ELSE(X11_FOUND)
+@@ -120,84 +120,9 @@ ELSE(X11_FOUND)
    MESSAGE(STATUS "Looking for XLib - not found")
  ENDIF(X11_FOUND)
  
@@ -15,27 +21,42 @@ index 0af63c1..bb3bb74 100644
 -  MESSAGE(STATUS "Looking for DRM - not found")
 -ENDIF(DRM_FOUND)
 -
+-include(CheckLibraryExists)
 -# DRM Intel
 -pkg_check_modules(DRM_INTEL libdrm_intel>=2.4.52)
 -IF(DRM_INTEL_FOUND)
 -  INCLUDE_DIRECTORIES(${DRM_INTEL_INCLUDE_DIRS})
 -  MESSAGE(STATUS "Looking for DRM Intel - found at ${DRM_INTEL_PREFIX} ${DRM_INTEL_VERSION}")
--  #userptr support starts from 2.4.57, but 2.4.58 is the actual stable release
--  IF(DRM_INTEL_VERSION VERSION_GREATER 2.4.57)
+-  CHECK_LIBRARY_EXISTS(drm_intel "drm_intel_bo_alloc_userptr" ${DRM_INTEL_LIBDIR} HAVE_DRM_INTEL_USERPTR)
+-  IF(HAVE_DRM_INTEL_USERPTR)
 -    MESSAGE(STATUS "Enable userptr support")
--    SET(DRM_INTEL_USERPTR "enable")
--  ELSE(DRM_INTEL_VERSION VERSION_GREATER 2.4.57)
+-  ELSE(HAVE_DRM_INTEL_USERPTR)
 -    MESSAGE(STATUS "Disable userptr support")
--  ENDIF(DRM_INTEL_VERSION VERSION_GREATER 2.4.57)
--  IF(DRM_INTEL_VERSION VERSION_GREATER 2.4.59)
+-  ENDIF(HAVE_DRM_INTEL_USERPTR)
+-  CHECK_LIBRARY_EXISTS(drm_intel "drm_intel_get_eu_total" ${DRM_INTEL_LIBDIR} HAVE_DRM_INTEL_EU_TOTAL)
+-  IF(HAVE_DRM_INTEL_EU_TOTAL)
 -    MESSAGE(STATUS "Enable EU total query support")
--    SET(DRM_INTEL_EU_TOTAL "enable")
--    MESSAGE(STATUS "Enable subslice total query support")
--    SET(DRM_INTEL_SUBSLICE_TOTAL "enable")
--  ELSE(DRM_INTEL_VERSION VERSION_GREATER 2.4.59)
+-  ELSE(HAVE_DRM_INTEL_EU_TOTAL)
 -    MESSAGE(STATUS "Disable EU total query support")
+-  ENDIF(HAVE_DRM_INTEL_EU_TOTAL)
+-  CHECK_LIBRARY_EXISTS(drm_intel "drm_intel_get_subslice_total" ${DRM_INTEL_LIBDIR} HAVE_DRM_INTEL_SUBSLICE_TOTAL)
+-  IF(HAVE_DRM_INTEL_SUBSLICE_TOTAL)
+-    MESSAGE(STATUS "Enable subslice total query support")
+-  ELSE(HAVE_DRM_INTEL_SUBSLICE_TOTAL)
 -    MESSAGE(STATUS "Disable subslice total query support")
--  ENDIF(DRM_INTEL_VERSION VERSION_GREATER 2.4.59)
+-  ENDIF(HAVE_DRM_INTEL_SUBSLICE_TOTAL)
+-  CHECK_LIBRARY_EXISTS(drm_intel "drm_intel_get_pooled_eu" "" HAVE_DRM_INTEL_POOLED_EU)
+-  IF(HAVE_DRM_INTEL_POOLED_EU)
+-    MESSAGE(STATUS "Enable pooled eu query support")
+-  ELSE(HAVE_DRM_INTEL_POOLED_EU)
+-    MESSAGE(STATUS "Disable pooled eu query support")
+-  ENDIF(HAVE_DRM_INTEL_POOLED_EU)
+-  CHECK_LIBRARY_EXISTS(drm_intel "drm_intel_get_min_eu_in_pool" "" HAVE_DRM_INTEL_MIN_EU_IN_POOL)
+-  IF(HAVE_DRM_INTEL_MIN_EU_IN_POOL)
+-    MESSAGE(STATUS "Enable min eu in pool query support")
+-  ELSE(HAVE_DRM_INTEL_MIN_EU_IN_POOL)
+-    MESSAGE(STATUS "Disable min eu in pool query support")
+-  ENDIF(HAVE_DRM_INTEL_MIN_EU_IN_POOL)
 -ELSE(DRM_INTEL_FOUND)
 -  MESSAGE(FATAL_ERROR "Looking for DRM Intel (>= 2.4.52) - not found")
 -ENDIF(DRM_INTEL_FOUND)
@@ -50,15 +71,6 @@ index 0af63c1..bb3bb74 100644
  Find_Package(Threads)
  
 -IF(X11_FOUND)
--# OpenGL (not use cmake helper)
--pkg_check_modules(OPENGL gl)
--IF(OPENGL_FOUND)
--  INCLUDE_DIRECTORIES(${OPENGL_INCLUDE_DIRS})
--  MESSAGE(STATUS "Looking for OpenGL - found at ${OPENGL_PREFIX}")
--ELSE(OPENGL_FOUND)
--  MESSAGE(STATUS "Looking for OpenGL - not found")
--ENDIF(OPENGL_FOUND)
--
 -# Xext
 -pkg_check_modules(XEXT REQUIRED xext)
 -IF(XEXT_FOUND)
@@ -78,19 +90,19 @@ index 0af63c1..bb3bb74 100644
 -ENDIF(XFIXES_FOUND)
 -ENDIF(X11_FOUND)
 -
- pkg_check_modules(EGL egl)
- IF(EGL_FOUND)
-   MESSAGE(STATUS "Looking for EGL - found at ${EGL_PREFIX}")
-@@ -260,13 +191,6 @@ ENDIF(BUILD_EXAMPLES)
+ OPTION(ENABLE_GL_SHARING "cl_khr_gl_sharing" OFF)
+ 
+ IF(ENABLE_GL_SHARING)
+@@ -268,13 +193,6 @@ ENDIF(BUILD_EXAMPLES)
  
  ADD_SUBDIRECTORY(include)
  ADD_SUBDIRECTORY(backend)
 -ADD_SUBDIRECTORY(src)
--ADD_SUBDIRECTORY(utests)
+-ADD_SUBDIRECTORY(utests EXCLUDE_FROM_ALL)
 -
 -# compile benchmark only if standalone compiler is not provided
 -IF (NOT (USE_STANDALONE_GBE_COMPILER STREQUAL "true"))
--ADD_SUBDIRECTORY(benchmark)
+-  ADD_SUBDIRECTORY(benchmark EXCLUDE_FROM_ALL)
 -ENDIF (NOT (USE_STANDALONE_GBE_COMPILER STREQUAL "true"))
  
  IF(BUILD_EXAMPLES)

--- a/meta-ostro-xt/recipes-opencl/beignet/beignet_1.2.bb
+++ b/meta-ostro-xt/recipes-opencl/beignet/beignet_1.2.bb
@@ -2,18 +2,17 @@ LICENSE = "LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6b566c5b4da35d474758324899cb4562"
 
 SRC_URI = "git://anongit.freedesktop.org/beignet \
-           file://respect-cflags.patch \
            file://fix-llvm-paths.patch \
-           file://0001-Add-support-for-more-Broxton-PCI-IDs.patch \
            "
+# add-ID's patch is broken to begin with...
+#SRC_URI_append = " file://0001-Add-support-for-more-Broxton-PCI-IDs.patch"
 SRC_URI_append_class-native = " file://reduced-native.patch"
 SRC_URI_append_class-target = " file://0001-Run-native-gbe_bin_generater-to-compile-built-in-ker.patch"
 
 BBCLASSEXTEND = "native"
-# TODO set PV to reflect that this is 1.1.2+patches.
+# TODO set PV to reflect that this is 1.2+patches.
 
-# Need a newer srcrev as 1.1.2 won't build with the LLVM release in meta-clang
-SRCREV = "8dfec54e2f3e32710702ed60f5171741360f28bb"
+SRCREV = "2c1f2468b82d855bc0b2ec08ddb7280790067e48"
 S = "${WORKDIR}/git"
 
 PROVIDES += "virtual/opencl-headers virtual/opencl-headers-cxx"


### PR DESCRIPTION
In order to make beignet compile with on host systems with gcc-6, update
is needed.

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
