### PR TITLE
swupd-client: define OstroXT's default URLs

### DIFF
--- a/meta-ostro-xt/recipes-swupd/swupd-client/swupd-client_%.bbappend
+++ b/meta-ostro-xt/recipes-swupd/swupd-client/swupd-client_%.bbappend
@@ -3,6 +3,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append = " \
     file://ostroprojectorg.key \
 "
+SWUPD_VERSION_URL ?= "https://download.ostroproject.org/updates/ostro-os-xt/milestone/intel-corei7-64/ostro-xt-image-swupd"
+SWUPD_CONTENT_URL ?= "https://download.ostroproject.org/updates/ostro-os-xt/milestone/intel-corei7-64/ostro-xt-image-swupd"
 
 do_install_append () {
     install -d ${D}${datadir}/clear/update-ca


### PR DESCRIPTION
Configure SWUPD client to use Ostro XT's update repositories by default.

This PR depends on the commit
http://git.yoctoproject.org/cgit/cgit.cgi/meta-swupd/commit/?id=4a970264a0cc6d284f510a0958cf577721e2d082
required to be merged to the ostro-os combo-layer.
