### PR TITLE
swupd-client: create state dir during install

### DIFF
--- a/meta-ostro-xt/recipes-swupd/swupd-client/swupd-client_%.bbappend
+++ b/meta-ostro-xt/recipes-swupd/swupd-client/swupd-client_%.bbappend
@@ -5,6 +5,7 @@ SRC_URI_append = " \
 "
 
 do_install_append () {
+    install -d ${D}${localstatedir}/lib/swupd
     install -d ${D}${datadir}/clear/update-ca
     rm -f ${D}${datadir}/clear/update-ca/425b0f6b.key
     install -m 0644 ${WORKDIR}/ostroprojectorg.key ${D}${datadir}/clear/update-ca/425b0f6b.key


### PR DESCRIPTION
The download cache directory (/var/lib/swupd) is not created in
swupd-client installation but the client creates it (and the necessary
subdirs) on the target before it is needed (e.g., in update).

In a SMACK enabled system this creates the following problem: by
default /var (and /var/lib) are set with SMACK64TRANSMUTE attribute.
Further, according to SMACK documentation: "If the object being created
is a directory the SMACK64TRANSMUTE attribute is set as well."
This means /var/lib/swupd created by swupd gets SMACK64TRANSMUTE and that
attribute propagates to all directories created when swupd runs untar
to unpack the update.

The original directories coming from the update do not have
SMACK64TRANSMUTE and changing xattrs trigger hash mismatches.

To solve the hash mismatch problem with SMACK64TRANSMUTEd directories,
create the directory in swupd-client install.

In addition, a SMACK label for /var/lib/swupd is needed to avoid
xattr_images_fix_transmute() walk (in xattr-images.bbclass) to skip
SMACK64TRANSMUTE setting for it. This is already taken care of
by swupd-client_%.bbappend in meta-ostro.

The regression occurs when Ostro XT moved from swupd 2.87 to swupd 3.x.
In 2.87, the state dirs were created in the recipe. The equivalent
step is now added in this change.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
