### PR TITLE
Add custom firewall rules to Ostro XT.

### DIFF
--- a/meta-ostro-xt/conf/distro/include/ostro-xt-supported-recipes.txt
+++ b/meta-ostro-xt/conf/distro/include/ostro-xt-supported-recipes.txt
@@ -48,6 +48,7 @@ hicolor-icon-theme@core
 iceauth@openembedded-layer
 initramfs-framework-installer@ostro-xt
 inputproto@core
+iptables-settings-xt@ostro-xt
 iso-codes@core
 kbproto@core
 libaio@core

--- a/meta-ostro-xt/conf/distro/ostro-xt.conf
+++ b/meta-ostro-xt/conf/distro/ostro-xt.conf
@@ -87,3 +87,6 @@ PREFERRED_VERSION_opencv = "3.%"
 # remove them.
 CFLAGS_remove = "-Wno-error=misleading-indentation"
 CXXFLAGS_remove = "-Wno-error=misleading-indentation"
+
+# Use custom default firewall settings.
+VIRTUAL-RUNTIME_iptables-settings = "iptables-settings-xt"

--- a/meta-ostro-xt/recipes-security/iptables-settings-xt/files/xt-ip6tables.rules
+++ b/meta-ostro-xt/recipes-security/iptables-settings-xt/files/xt-ip6tables.rules
@@ -1,0 +1,19 @@
+*filter
+:INPUT DROP
+:FORWARD DROP
+:OUTPUT ACCEPT
+# Intel System Studio
+-A INPUT -p tcp -m tcp --dport 2345 -j ACCEPT
+# Intel XDK
+-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+# allow containers to access DNS service
+-A INPUT -i ve-+ -p udp -m udp --dport 53 -j ACCEPT
+-A INPUT -i lo -j ACCEPT
+# allow DHCPv6
+-A INPUT -s fe80::/10 -p udp -m udp --dport 546 -j ACCEPT
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
+# allow forwarding traffic to/from containers
+-A FORWARD -o ve-+ -j ACCEPT
+-A FORWARD -i ve-+ -j ACCEPT
+COMMIT

--- a/meta-ostro-xt/recipes-security/iptables-settings-xt/files/xt-iptables.rules
+++ b/meta-ostro-xt/recipes-security/iptables-settings-xt/files/xt-iptables.rules
@@ -1,0 +1,18 @@
+*filter
+:INPUT DROP
+:FORWARD DROP
+:OUTPUT ACCEPT
+# Intel System Studio
+-A INPUT -p tcp -m tcp --dport 2345 -j ACCEPT
+# Intel XDK
+-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+# allow containers to access DNS service
+-A INPUT -i ve-+ -p udp -m udp --dport 53 -j ACCEPT
+# allow containers to access DHCP service
+-A INPUT -i ve-+ -p udp -m udp --dport 67 -j ACCEPT
+-A INPUT -i lo -j ACCEPT
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+# allow forwarding traffic to/from containers
+-A FORWARD -o ve-+ -j ACCEPT
+-A FORWARD -i ve-+ -j ACCEPT
+COMMIT

--- a/meta-ostro-xt/recipes-security/iptables-settings-xt/iptables-settings-xt_0.1.bb
+++ b/meta-ostro-xt/recipes-security/iptables-settings-xt/iptables-settings-xt_0.1.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "Ostro XT iptables and ip6tables settings."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://xt-iptables.rules \
+    file://xt-ip6tables.rules \
+"
+
+inherit update-alternatives
+
+# If you have a system without IPv6 support, just drop out the
+# configuration files for ip6tables.
+
+ALTERNATIVE_${PN} += "iptables.rules ip6tables.rules"
+ALTERNATIVE_LINK_NAME[iptables.rules] = "${datadir}/iptables-settings/iptables.rules"
+ALTERNATIVE_LINK_NAME[ip6tables.rules] = "${datadir}/iptables-settings/ip6tables.rules"
+ALTERNATIVE_TARGET[iptables.rules] = "${datadir}/iptables-settings/xt-iptables.rules"
+ALTERNATIVE_TARGET[ip6tables.rules] = "${datadir}/iptables-settings/xt-ip6tables.rules"
+
+FILES_${PN} += "${datadir}/iptables-settings/"
+
+do_install() {
+    install -d ${D}${datadir}/iptables-settings
+    install -m 0644 ${WORKDIR}/xt-iptables.rules ${D}${datadir}/iptables-settings/xt-iptables.rules
+    install -m 0644 ${WORKDIR}/xt-ip6tables.rules ${D}${datadir}/iptables-settings/xt-ip6tables.rules
+}


### PR DESCRIPTION
Open TCP ports 22 and 2345 to allow IDE integration. Also update the ip6tables firewall settings to match the current Ostro OS security level.
