### PR TITLE
libidn: backported libidn 1.33 from ostro-os.

### DIFF
--- a/meta-ostro-xt/conf/distro/include/ostro-xt-supported-recipes.txt
+++ b/meta-ostro-xt/conf/distro/include/ostro-xt-supported-recipes.txt
@@ -65,6 +65,7 @@ libglu@core
 libgphoto2@openembedded-layer
 libgudev@core
 libice@core
+libidn@ostro-xt
 libnewt@core
 libnotify@core
 libogg@core

--- a/meta-ostro-xt/recipes-extended/libidn/libidn/0001-idn-fix-printf-format-security-warnings.patch
+++ b/meta-ostro-xt/recipes-extended/libidn/libidn/0001-idn-fix-printf-format-security-warnings.patch
@@ -1,0 +1,181 @@
+From 82f98dcbc429bbe89a9837c533cbcbc02e77c790 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <adraszik@tycoint.com>
+Date: Tue, 28 Jun 2016 12:43:31 +0100
+Subject: [PATCH] idn: fix printf() format security warnings
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+| ../../libidn-1.32/src/idn.c: In function 'main':
+| ../../libidn-1.32/src/idn.c:172:7: error: format not a string literal and no format arguments [-Werror=format-security]
+|        error (0, 0, _("only one of -s, -e, -d, -a, -u or -n can be specified"));
+|        ^~~~~
+| ../../libidn-1.32/src/idn.c:187:5: error: format not a string literal and no format arguments [-Werror=format-security]
+|      fprintf (stderr, _("Type each input string on a line by itself, "
+|      ^~~~~~~
+| ../../libidn-1.32/src/idn.c:202:4: error: format not a string literal and no format arguments [-Werror=format-security]
+|     error (EXIT_FAILURE, errno, _("input error"));
+|     ^~~~~
+| ../../libidn-1.32/src/idn.c:220:8: error: format not a string literal and no format arguments [-Werror=format-security]
+|         _("could not convert from UTF-8 to UCS-4"));
+|         ^
+| ../../libidn-1.32/src/idn.c:245:8: error: format not a string literal and no format arguments [-Werror=format-security]
+|         _("could not convert from UTF-8 to UCS-4"));
+|         ^
+| ../../libidn-1.32/src/idn.c:281:6: error: format not a string literal and no format arguments [-Werror=format-security]
+|       _("could not convert from UTF-8 to UCS-4"));
+|       ^
+| ../../libidn-1.32/src/idn.c:340:6: error: format not a string literal and no format arguments [-Werror=format-security]
+|       _("could not convert from UCS-4 to UTF-8"));
+|       ^
+| ../../libidn-1.32/src/idn.c:364:6: error: format not a string literal and no format arguments [-Werror=format-security]
+|       _("could not convert from UCS-4 to UTF-8"));
+|       ^
+| ../../libidn-1.32/src/idn.c:442:8: error: format not a string literal and no format arguments [-Werror=format-security]
+|         _("could not convert from UCS-4 to UTF-8"));
+|         ^
+| ../../libidn-1.32/src/idn.c:498:6: error: format not a string literal and no format arguments [-Werror=format-security]
+|       _("could not convert from UTF-8 to UCS-4"));
+|       ^
+| ../../libidn-1.32/src/idn.c:527:5: error: format not a string literal and no format arguments [-Werror=format-security]
+|      _("could not convert from UTF-8 to UCS-4"));
+|      ^
+| ../../libidn-1.32/src/idn.c:540:6: error: format not a string literal and no format arguments [-Werror=format-security]
+|       error (EXIT_FAILURE, 0, _("could not do NFKC normalization"));
+|       ^~~~~
+| ../../libidn-1.32/src/idn.c:551:5: error: format not a string literal and no format arguments [-Werror=format-security]
+|      _("could not convert from UTF-8 to UCS-4"));
+|      ^
+
+Signed-off-by: André Draszik <adraszik@tycoint.com>
+---
+Upstream-Status: Pending
+
+ src/idn.c | 27 ++++++++++++++-------------
+ 1 file changed, 14 insertions(+), 13 deletions(-)
+
+diff --git a/src/idn.c b/src/idn.c
+index be1c7d1..68e4291 100644
+--- a/src/idn.c
++++ b/src/idn.c
+@@ -170,7 +170,7 @@ main (int argc, char *argv[])
+       (args_info.idna_to_unicode_given ? 1 : 0) +
+       (args_info.nfkc_given ? 1 : 0) != 1)
+     {
+-      error (0, 0, _("only one of -s, -e, -d, -a, -u or -n can be specified"));
++      error (0, 0, "%s", _("only one of -s, -e, -d, -a, -u or -n can be specified"));
+       usage (EXIT_FAILURE);
+     }
+ 
+@@ -185,7 +185,7 @@ main (int argc, char *argv[])
+   if (!args_info.quiet_given
+       && args_info.inputs_num == 0
+       && isatty (fileno (stdin)))
+-    fprintf (stderr, _("Type each input string on a line by itself, "
++    fprintf (stderr, "%s", _("Type each input string on a line by itself, "
+ 		       "terminated by a newline character.\n"));
+ 
+   do
+@@ -197,7 +197,7 @@ main (int argc, char *argv[])
+ 	  if (feof (stdin))
+ 	    break;
+ 
+-	  error (EXIT_FAILURE, errno, _("input error"));
++	  error (EXIT_FAILURE, errno, "%s", _("input error"));
+ 	}
+ 
+       if (strlen (line) > 0)
+@@ -215,7 +215,7 @@ main (int argc, char *argv[])
+ 	  if (!q)
+ 	    {
+ 	      free (p);
+-	      error (EXIT_FAILURE, 0,
++	      error (EXIT_FAILURE, 0, "%s",
+ 		     _("could not convert from UTF-8 to UCS-4"));
+ 	    }
+ 
+@@ -240,7 +240,7 @@ main (int argc, char *argv[])
+ 	  if (!q)
+ 	    {
+ 	      free (r);
+-	      error (EXIT_FAILURE, 0,
++	      error (EXIT_FAILURE, 0, "%s",
+ 		     _("could not convert from UTF-8 to UCS-4"));
+ 	    }
+ 
+@@ -277,7 +277,7 @@ main (int argc, char *argv[])
+ 	  q = stringprep_utf8_to_ucs4 (p, -1, &len);
+ 	  free (p);
+ 	  if (!q)
+-	    error (EXIT_FAILURE, 0,
++	    error (EXIT_FAILURE, 0, "%s",
+ 		   _("could not convert from UTF-8 to UCS-4"));
+ 
+ 	  if (args_info.debug_given)
+@@ -336,7 +336,7 @@ main (int argc, char *argv[])
+ 	  r = stringprep_ucs4_to_utf8 (q, -1, NULL, NULL);
+ 	  free (q);
+ 	  if (!r)
+-	    error (EXIT_FAILURE, 0,
++	    error (EXIT_FAILURE, 0, "%s",
+ 		   _("could not convert from UCS-4 to UTF-8"));
+ 
+ 	  p = stringprep_utf8_to_locale (r);
+@@ -360,7 +360,7 @@ main (int argc, char *argv[])
+ 	  q = stringprep_utf8_to_ucs4 (p, -1, NULL);
+ 	  free (p);
+ 	  if (!q)
+-	    error (EXIT_FAILURE, 0,
++	    error (EXIT_FAILURE, 0, "%s",
+ 		   _("could not convert from UCS-4 to UTF-8"));
+ 
+ 	  if (args_info.debug_given)
+@@ -438,7 +438,7 @@ main (int argc, char *argv[])
+ 	  if (!q)
+ 	    {
+ 	      free (p);
+-	      error (EXIT_FAILURE, 0,
++	      error (EXIT_FAILURE, 0, "%s",
+ 		     _("could not convert from UCS-4 to UTF-8"));
+ 	    }
+ 
+@@ -494,7 +494,7 @@ main (int argc, char *argv[])
+ 	  r = stringprep_ucs4_to_utf8 (q, -1, NULL, NULL);
+ 	  free (q);
+ 	  if (!r)
+-	    error (EXIT_FAILURE, 0,
++	    error (EXIT_FAILURE, 0, "%s",
+ 		   _("could not convert from UTF-8 to UCS-4"));
+ 
+ 	  p = stringprep_utf8_to_locale (r);
+@@ -523,7 +523,7 @@ main (int argc, char *argv[])
+ 	      if (!q)
+ 		{
+ 		  free (p);
+-		  error (EXIT_FAILURE, 0,
++		  error (EXIT_FAILURE, 0, "%s",
+ 			 _("could not convert from UTF-8 to UCS-4"));
+ 		}
+ 
+@@ -537,7 +537,8 @@ main (int argc, char *argv[])
+ 	  r = stringprep_utf8_nfkc_normalize (p, -1);
+ 	  free (p);
+ 	  if (!r)
+-	    error (EXIT_FAILURE, 0, _("could not do NFKC normalization"));
++	    error (EXIT_FAILURE, 0, "%s",
++		   _("could not do NFKC normalization"));
+ 
+ 	  if (args_info.debug_given)
+ 	    {
+@@ -547,7 +548,7 @@ main (int argc, char *argv[])
+ 	      if (!q)
+ 		{
+ 		  free (r);
+-		  error (EXIT_FAILURE, 0,
++		  error (EXIT_FAILURE, 0, "%s",
+ 			 _("could not convert from UTF-8 to UCS-4"));
+ 		}
+ 
+-- 
+2.8.1
+

--- a/meta-ostro-xt/recipes-extended/libidn/libidn/avoid_AM_PROG_MKDIR_P_warning_error_with_automake_1.12.patch
+++ b/meta-ostro-xt/recipes-extended/libidn/libidn/avoid_AM_PROG_MKDIR_P_warning_error_with_automake_1.12.patch
@@ -1,0 +1,25 @@
+Upstream-Status: Inappropriate 
+
+automake 1.12.x has deprecated AM_PROG_MKDIR_P , and throws a warning for that,
+and the warnings are treated as errors because of the -Werror parameter.
+
+These AM_PROG_MKDIR_P are coming from gettext, and the latest gettext code has not 
+eliminated these deprecated macros yet. So disable the treatment of warnings
+as errors until gettext is updated to remove the deprecated macros.
+
+Signed-off-by: Nitin A Kamble <nitin.a.kamble@intel.com>
+2012/07/10
+
+Index: libidn-1.24/configure.ac
+===================================================================
+--- libidn-1.24.orig/configure.ac
++++ libidn-1.24/configure.ac
+@@ -23,7 +23,7 @@ AC_COPYRIGHT([Copyright (c) 2002-2011 Si
+ AC_CONFIG_AUX_DIR([build-aux])
+ AC_CONFIG_MACRO_DIR([m4])
+ AC_CONFIG_HEADERS(config.h)
+-AM_INIT_AUTOMAKE([1.10 -Wall -Werror -Wno-override])
++AM_INIT_AUTOMAKE([1.10 -Wall -Wno-override])
+ AM_SILENT_RULES([yes])
+ 
+ # Library code modified:                              REVISION++

--- a/meta-ostro-xt/recipes-extended/libidn/libidn/dont-depend-on-help2man.patch
+++ b/meta-ostro-xt/recipes-extended/libidn/libidn/dont-depend-on-help2man.patch
@@ -1,0 +1,23 @@
+Upstream-Status: Inappropriate [disable feature]
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+diff -Nurdd libidn-1.26/doc/Makefile.am libidn-1.26/doc/Makefile.am
+--- libidn-1.26/doc/Makefile.am	2012-09-18 11:25:45.000000000 +0300
++++ libidn-1.26/doc/Makefile.am	2013-02-08 07:41:24.591431462 +0200
+@@ -49,15 +49,9 @@
+
+ # Man pages.
+
+-dist_man_MANS = idn.1 $(gdoc_MANS)
++dist_man_MANS = $(gdoc_MANS)
+ MAINTAINERCLEANFILES = $(dist_man_MANS)
+
+-idn.1: $(top_srcdir)/src/idn.c $(top_srcdir)/src/idn.ggo \
+-		$(top_srcdir)/configure.ac
+-	$(HELP2MAN) \
+-		--name="Internationalized Domain Names command line tool" \
+-		--output=$@ $(top_builddir)/src/idn$(EXEEXT)
+-
+ # GDOC
+
+ GDOC_BIN = $(srcdir)/gdoc

--- a/meta-ostro-xt/recipes-extended/libidn/libidn/libidn_fix_for_automake-1.12.patch
+++ b/meta-ostro-xt/recipes-extended/libidn/libidn/libidn_fix_for_automake-1.12.patch
@@ -1,0 +1,26 @@
+Upstream-Status: Pending
+
+This patch fixes following issue with automake 1.12
+
+| automake: warnings are treated as errors
+| /srv/home/nitin/builds/build-gcc47/tmp/sysroots/x86_64-linux/usr/share/automake-1.12/am/ltlibrary.am: warning: 'libidn.la': linking libtool libraries using a non-POSIX
+| /srv/home/nitin/builds/build-gcc47/tmp/sysroots/x86_64-linux/usr/share/automake-1.12/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac'
+
+Signed-off-by: Nitin A Kamble <nitin.a.kamble@intel.com>
+2012/05/03
+
+Index: libidn-1.24/configure.ac
+===================================================================
+--- libidn-1.24.orig/configure.ac
++++ libidn-1.24/configure.ac
+@@ -34,6 +34,10 @@ AC_SUBST(LT_CURRENT, 17)
+ AC_SUBST(LT_REVISION, 7)
+ AC_SUBST(LT_AGE, 6)
+ 
++# automake 1.12 seems to require this, but automake 1.11 doesn't recognize it
++m4_pattern_allow([AM_PROG_AR])
++AM_PROG_AR
++
+ AC_PROG_CC
+ gl_EARLY
+ lgl_EARLY

--- a/meta-ostro-xt/recipes-extended/libidn/libidn_1.33.bb
+++ b/meta-ostro-xt/recipes-extended/libidn/libidn_1.33.bb
@@ -1,0 +1,42 @@
+SUMMARY = "Internationalized Domain Name support library"
+DESCRIPTION = "Implementation of the Stringprep, Punycode and IDNA specifications defined by the IETF Internationalized Domain Names (IDN) working group."
+HOMEPAGE = "http://www.gnu.org/software/libidn/"
+SECTION = "libs"
+LICENSE = "(LGPLv2.1+ | LGPLv3) & GPLv3+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=df4be47940a91ee69556f5f71eed4aec \
+                    file://COPYING.LESSERv2;md5=4fbd65380cdd255951079008b364516c \
+                    file://COPYING.LESSERv3;md5=e6a600fd5e1d9cbde2d983680233ad02 \
+                    file://COPYINGv2;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYINGv3;md5=d32239bcb673463ab874e80d47fae504 \
+                    file://lib/idna.h;endline=21;md5=37cffad24807f446a24de3e7371f20b9 \
+                    file://src/idn.c;endline=20;md5=09e97034a8877b3451cb65065fc2c06e"
+DEPENDS = "virtual/libiconv"
+
+inherit pkgconfig autotools gettext texinfo gtk-doc
+
+SRC_URI = "${GNU_MIRROR}/libidn/${BPN}-${PV}.tar.gz \
+           file://libidn_fix_for_automake-1.12.patch \
+           file://avoid_AM_PROG_MKDIR_P_warning_error_with_automake_1.12.patch \
+           file://dont-depend-on-help2man.patch \
+           file://0001-idn-fix-printf-format-security-warnings.patch \
+"
+
+SRC_URI[md5sum] = "a9aa7e003665de9c82bd3f9fc6ccf308"
+SRC_URI[sha256sum] = "44a7aab635bb721ceef6beecc4d49dfd19478325e1b47f3196f7d2acc4930e19"
+
+# command tool is under GPLv3+, while libidn itself is under LGPLv2.1+ or LGPLv3
+# so package command into a separate package
+PACKAGES =+ "idn"
+FILES_idn = "${bindir}/*"
+
+LICENSE_${PN} = "LGPLv2.1+ | LGPLv3"
+LICENSE_idn = "GPLv3+"
+
+EXTRA_OECONF = "--disable-csharp"
+
+do_install_append() {
+	rm -rf ${D}${datadir}/emacs
+}
+
+BBCLASSEXTEND = "native nativesdk"
+


### PR DESCRIPTION
Libidn 1.33 is backported from ostro-os commit
https://github.com/ostroproject/ostro-os/commit/8e54e11d5a0a8fdf618b761c28903e7705e99f92.

Also updated the supported recipes list. Revert this patch when a later ostro-os version is pulled in to ostro-xt.
