### PR TITLE
openssl: security fix CVE-2016-6304

### DIFF
--- a/meta-ostro-xt/recipes-connectivity/openssl/files/CVE-2016-6304.patch
+++ b/meta-ostro-xt/recipes-connectivity/openssl/files/CVE-2016-6304.patch
@@ -1,0 +1,75 @@
+From ea39b16b71e4e72a228a4535bd6d6a02c5edbc1f Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Fri, 9 Sep 2016 10:08:45 +0100
+Subject: [PATCH] Fix OCSP Status Request extension unbounded memory growth
+
+A malicious client can send an excessively large OCSP Status Request
+extension. If that client continually requests renegotiation,
+sending a large OCSP Status Request extension each time, then there will
+be unbounded memory growth on the server. This will eventually lead to a
+Denial Of Service attack through memory exhaustion. Servers with a
+default configuration are vulnerable even if they do not support OCSP.
+Builds using the "no-ocsp" build time option are not affected.
+
+I have also checked other extensions to see if they suffer from a similar
+problem but I could not find any other issues.
+
+CVE-2016-6304
+
+Issue reported by Shi Lei.
+Reviewed-by: Rich Salz <rsalz@openssl.org>
+
+CVE: CVE-2016-6304
+Upstream-Status: Backport
+https://github.com/openssl/openssl/commit/e408c09bbf7c3057bda4b8d20bec1b3a7771c15b
+
+Signed-off-by: Anuj Mittal <anujx.mittal@intel.com>
+---
+ ssl/t1_lib.c | 24 +++++++++++++++++-------
+ 1 file changed, 17 insertions(+), 7 deletions(-)
+
+diff --git a/ssl/t1_lib.c b/ssl/t1_lib.c
+index fbcf2e6..e4b4e27 100644
+--- a/ssl/t1_lib.c
++++ b/ssl/t1_lib.c
+@@ -2316,6 +2316,23 @@ static int ssl_scan_clienthello_tlsext(SSL *s, unsigned char **p,
+                 size -= 2;
+                 if (dsize > size)
+                     goto err;
++
++                /*
++                 * We remove any OCSP_RESPIDs from a previous handshake
++                 * to prevent unbounded memory growth - CVE-2016-6304
++                 */
++                sk_OCSP_RESPID_pop_free(s->tlsext_ocsp_ids,
++                                        OCSP_RESPID_free);
++                if (dsize > 0) {
++                    s->tlsext_ocsp_ids = sk_OCSP_RESPID_new_null();
++                    if (s->tlsext_ocsp_ids == NULL) {
++                        *al = SSL_AD_INTERNAL_ERROR;
++                        return 0;
++                    }
++                } else {
++                    s->tlsext_ocsp_ids = NULL;
++                }
++
+                 while (dsize > 0) {
+                     OCSP_RESPID *id;
+                     int idsize;
+@@ -2335,13 +2352,6 @@ static int ssl_scan_clienthello_tlsext(SSL *s, unsigned char **p,
+                         OCSP_RESPID_free(id);
+                         goto err;
+                     }
+-                    if (!s->tlsext_ocsp_ids
+-                        && !(s->tlsext_ocsp_ids =
+-                             sk_OCSP_RESPID_new_null())) {
+-                        OCSP_RESPID_free(id);
+-                        *al = SSL_AD_INTERNAL_ERROR;
+-                        return 0;
+-                    }
+                     if (!sk_OCSP_RESPID_push(s->tlsext_ocsp_ids, id)) {
+                         OCSP_RESPID_free(id);
+                         *al = SSL_AD_INTERNAL_ERROR;
+-- 
+1.9.1
+

--- a/meta-ostro-xt/recipes-connectivity/openssl/openssl_1.0.2h.bbappend
+++ b/meta-ostro-xt/recipes-connectivity/openssl/openssl_1.0.2h.bbappend
@@ -1,2 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI_append = " file://CVE-2016-2180.patch"
+SRC_URI += " \
+    file://CVE-2016-2180.patch \
+    file://CVE-2016-6304.patch \
+"


### PR DESCRIPTION
Adds just the fix for the critical CVE instead of updating to 1.0.2i,
which would bring in additional changes.
