### PR TITLE
Backport CVE fixes for Flex and Gnutls.

### DIFF
--- a/meta-ostro-xt/recipes-devtools/flex/files/CVE-2016-6354.patch
+++ b/meta-ostro-xt/recipes-devtools/flex/files/CVE-2016-6354.patch
@@ -1,0 +1,59 @@
+From 3939eccdff598f47e5b37b05d58bf1b44d3796e7 Mon Sep 17 00:00:00 2001
+From: Jussi Kukkonen <jussi.kukkonen@intel.com>
+Date: Fri, 7 Oct 2016 14:15:38 +0300
+Subject: [PATCH] Prevent buffer overflow in yy_get_next_buffer
+
+This is upstream commit a5cbe929ac3255d371e698f62dc256afe7006466
+with some additional backporting to make binutils build again.
+
+Upstream-Status: Backport
+CVE: CVE-2016-6354
+Signed-off-by: Jussi Kukkonen <jussi.kukkonen@intel.com>
+---
+ src/flex.skl | 2 +-
+ src/scan.c   | 2 +-
+ src/skel.c   | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/flex.skl b/src/flex.skl
+index ed71627..814d562 100644
+--- a/src/flex.skl
++++ b/src/flex.skl
+@@ -1718,7 +1718,7 @@ int yyFlexLexer::yy_get_next_buffer()
+ 
+ 	else
+ 		{
+-			yy_size_t num_to_read =
++			int num_to_read =
+ 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
+ 
+ 		while ( num_to_read <= 0 )
+diff --git a/src/scan.c b/src/scan.c
+index f1dce75..1949872 100644
+--- a/src/scan.c
++++ b/src/scan.c
+@@ -4181,7 +4181,7 @@ static int yy_get_next_buffer (void)
+ 
+ 	else
+ 		{
+-			yy_size_t num_to_read =
++			int num_to_read =
+ 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
+ 
+ 		while ( num_to_read <= 0 )
+diff --git a/src/skel.c b/src/skel.c
+index 26cc889..0344d18 100644
+--- a/src/skel.c
++++ b/src/skel.c
+@@ -1929,7 +1929,7 @@ const char *skel[] = {
+   "",
+   "	else",
+   "		{",
+-  "			yy_size_t num_to_read =",
++  "			int num_to_read =",
+   "			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;",
+   "",
+   "		while ( num_to_read <= 0 )",
+-- 
+2.1.4
+

--- a/meta-ostro-xt/recipes-devtools/flex/flex_2.6.0.bbappend
+++ b/meta-ostro-xt/recipes-devtools/flex/flex_2.6.0.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append = " file://CVE-2016-6354.patch"

--- a/meta-ostro-xt/recipes-support/gnutls/files/CVE-2016-7444.patch
+++ b/meta-ostro-xt/recipes-support/gnutls/files/CVE-2016-7444.patch
@@ -1,0 +1,35 @@
+CVE: CVE-2016-7444
+Upstream-Status: Backport
+Signed-off-by: Jussi Kukkonen <jussi.kukkonen@intel.com>
+
+Upstream commit follows:
+
+
+From 964632f37dfdfb914ebc5e49db4fa29af35b1de9 Mon Sep 17 00:00:00 2001
+From: Nikos Mavrogiannopoulos <nmav@gnutls.org>
+Date: Sat, 27 Aug 2016 17:00:22 +0200
+Subject: [PATCH] ocsp: corrected the comparison of the serial size in OCSP response
+
+Previously the OCSP certificate check wouldn't verify the serial length
+and could succeed in cases it shouldn't.
+
+Reported by Stefan Buehler.
+---
+ lib/x509/ocsp.c | 1 +
+ 1 file changed, 1 insertion(+), 0 deletions(-)
+
+diff --git a/lib/x509/ocsp.c b/lib/x509/ocsp.c
+index 92db9b6..8181f2e 100644
+--- a/lib/x509/ocsp.c
++++ b/lib/x509/ocsp.c
+@@ -1318,6 +1318,7 @@ gnutls_ocsp_resp_check_crt(gnutls_ocsp_resp_t resp,
+ 		gnutls_assert();
+ 		goto cleanup;
+ 	}
++	cserial.size = t;
+ 
+ 	if (rserial.size != cserial.size
+ 	    || memcmp(cserial.data, rserial.data, rserial.size) != 0) {
+--
+libgit2 0.24.0
+

--- a/meta-ostro-xt/recipes-support/gnutls/gnutls_%.bbappend
+++ b/meta-ostro-xt/recipes-support/gnutls/gnutls_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append = " file://CVE-2016-7444.patch"


### PR DESCRIPTION
Fixes two Ostro OS vulnerabilities: https://github.com/ostroproject/ostro-os/issues/194 and https://github.com/ostroproject/ostro-os/issues/196 (CVE-2016-6354 and  CVE-2016-7444).
