### PR TITLE
joule-udev-rules: enable power management for all USB devices

### DIFF
--- a/meta-ostro-xt/recipes-bsp/joule-udev-rules/files/usb-autosuspend-blacklist
+++ b/meta-ostro-xt/recipes-bsp/joule-udev-rules/files/usb-autosuspend-blacklist
@@ -1,0 +1,12 @@
+# This file lists USB devices which do not work properly when
+# USB autosuspend is enabled.
+#
+# Comments are ignored, blacklisted devices are identified
+# with four-digit vendor:product IDs as listed by lsusb.
+# Not spaces allowed before the ID pair. It may be followed by
+# spaces and further comments.
+#
+# For example, to blacklist the following device, uncomment the line:
+#dead:beef # fictional device with vendor ID dead and product ID beef
+#
+# Read-only file. To add devices locally, create /etc/udev/usb-autosuspend-blacklist

--- a/meta-ostro-xt/recipes-bsp/joule-udev-rules/files/usb-power.rules
+++ b/meta-ostro-xt/recipes-bsp/joule-udev-rules/files/usb-power.rules
@@ -1,0 +1,15 @@
+# This file enables autosuspend for USB devices by default. Devices
+# that do not work properly in that mode can be blacklisted by adding
+# their <vendor>:<product> pair (as printed by lsusb) to
+# /lib/udev/usb-autosuspend-blacklist (read-only, maintained as part
+# of the OS) or the same file in /etc/udev (read/write, maintained by
+# users).
+
+# Check whether device is blacklisted.
+ACTION=="add", SUBSYSTEMS=="usb", PROGRAM="/bin/sh -c 'grep -q ^$attr{idVendor}:$attr{idProduct} /lib/udev/usb-autosuspend-blacklist || ( [ -e /etc/udev/usb-autosuspend-blacklist ] && grep -q $attr{idVendor}:$attr{idProduct} /etc/udev/usb-autosuspend-blacklist)'", GOTO="power_usb_rules_end"
+
+# Enable autosuspend.
+ACTION=="add", SUBSYSTEMS=="usb", TEST=="power/control", ATTR{power/control}="auto"
+
+# Done.
+LABEL="power_usb_rules_end"

--- a/meta-ostro-xt/recipes-bsp/joule-udev-rules/joule-udev-rules_1.0.bb
+++ b/meta-ostro-xt/recipes-bsp/joule-udev-rules/joule-udev-rules_1.0.bb
@@ -6,6 +6,8 @@ SRC_URI += " \
     file://sysfs-control.sh \
     file://pci-power.rules \
     file://hdmi-hotplug.rules \
+    file://usb-power.rules \
+    file://usb-autosuspend-blacklist \
 "
 
 do_install_append () {
@@ -14,5 +16,8 @@ do_install_append () {
     install -m 0755 -d ${D}/${base_libdir}/udev/rules.d
     install -m 0644 ${WORKDIR}/hdmi-hotplug.rules ${D}/${base_libdir}/udev/rules.d/79-hdmi-hotplug.rules
     install -m 0644 ${WORKDIR}/pci-power.rules ${D}/${base_libdir}/udev/rules.d/80-pci-power.rules
+    install -m 0644 ${WORKDIR}/usb-power.rules ${D}/${base_libdir}/udev/rules.d/80-usb-power.rules
+    install -m 0644 ${WORKDIR}/usb-autosuspend-blacklist ${D}/${base_libdir}/udev/
 }
 
+FILES_${PN} += "${base_libdir}/udev/usb-autosuspend-blacklist"


### PR DESCRIPTION
The Linux default is to keep USB devices powered on because there are
(broken) USB devices which don't work properly when power management
is active (see Documentation/usb/power-management.txt).

For Joule, the decision was made that this risk is acceptable
considering the power saving that can be obtained when enabling
USB power management.

@jlaako: does this PR look right? I verified manually such a udev rule
has the desired effect; I haven't checked the images created with this
PR.
