### PR TITLE
CI and build scripts: Improve compatibility by avoiding -v tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,54 +40,51 @@ def testinfo_data = ""
 try {
     node('docker') {
         ws ("workspace/builder-slot-${env.EXECUTOR_NUMBER}") {
-            stage 'Cleanup workspace'
-            deleteDir()
-
-            stage 'Checkout own content'
-            if (binding.variables.get("GITHUB_PR_NUMBER")) {
-                // we are building pull request
-                checkout([$class: 'GitSCM',
-                    branches: [
-                        [name: "origin-pull/$GITHUB_PR_NUMBER/$GITHUB_PR_COND_REF"]
-                    ],
-                    doGenerateSubmoduleConfigurations: false,
-                    extensions: [
-                        [$class: 'SubmoduleOption',
-                            disableSubmodules: false,
-                            recursiveSubmodules: true,
-                            reference: "${env.PUBLISH_DIR}/bb-cache/.git-mirror",
-                            trackingSubmodules: false],
-                        [$class: 'CleanBeforeCheckout']
-                    ],
-                    submoduleCfg: [],
-                        userRemoteConfigs: [
-                        [
-                            credentialsId: "${GITHUB_AUTH}",
-                            name: 'origin-pull',
-                            refspec: "+refs/pull/$GITHUB_PR_NUMBER/*:refs/remotes/origin-pull/$GITHUB_PR_NUMBER/*",
-                            url: "${GITHUB_PROJECT}"
-                        ]
-                    ]
-                ])
-            } else {
-                checkout poll: false, scm: scm
-            }
-
-            stage 'Cleanup old build directory'
-            dir('build') {
+            stage('Cleanup workspace') {
                 deleteDir()
             }
 
-            stage 'Build docker image'
-            if (is_pr) {
-                setGitHubPullRequestStatus state: 'PENDING', context: "${env.JOB_NAME}", message: "Building Docker image"
+            stage('Checkout own content') {
+                if (binding.variables.get("GITHUB_PR_NUMBER")) {
+                    // we are building pull request
+                    checkout([$class: 'GitSCM',
+                        branches: [
+                            [name: "origin-pull/$GITHUB_PR_NUMBER/$GITHUB_PR_COND_REF"]
+                        ],
+                        doGenerateSubmoduleConfigurations: false,
+                        extensions: [
+                            [$class: 'SubmoduleOption',
+                                disableSubmodules: false,
+                                recursiveSubmodules: true,
+                                reference: "${env.PUBLISH_DIR}/bb-cache/.git-mirror",
+                                trackingSubmodules: false],
+                            [$class: 'CleanBeforeCheckout']
+                        ],
+                        submoduleCfg: [],
+                            userRemoteConfigs: [
+                            [
+                                credentialsId: "${GITHUB_AUTH}",
+                                name: 'origin-pull',
+                                refspec: "+refs/pull/$GITHUB_PR_NUMBER/*:refs/remotes/origin-pull/$GITHUB_PR_NUMBER/*",
+                                url: "${GITHUB_PROJECT}"
+                            ]
+                        ]
+                    ])
+                } else {
+                    checkout poll: false, scm: scm
+                }
             }
 
-            def build_args = [ build_proxy_args(), build_user_args()].join(" ")
+            stage('Build docker image') {
+                if (is_pr) {
+                    setGitHubPullRequestStatus state: 'PENDING', context: "${env.JOB_NAME}", message: "Building Docker image"
+                }
 
-            sh "docker build -t ${image_name} ${build_args} docker/${build_os}"
-            dockerFingerprintFrom dockerfile: "docker/${build_os}/Dockerfile", image: "${image_name}"
+                def build_args = [ build_proxy_args(), build_user_args()].join(" ")
 
+                sh "docker build -t ${image_name} ${build_args} docker/${build_os}"
+                dockerFingerprintFrom dockerfile: "docker/${build_os}/Dockerfile", image: "${image_name}"
+            }
             def docker_image = docker.image(image_name)
 
             run_args = ["-v ${env.PUBLISH_DIR}:${env.PUBLISH_DIR}:rw",
@@ -110,21 +107,22 @@ try {
             timestamps {
             sshagent(['github-auth-ssh']) {
                 docker_image.inside(run_args) {
-                    stage 'Bitbake Build'
-                    if (is_pr) {
-                        setGitHubPullRequestStatus state: 'PENDING', context: "${env.JOB_NAME}", message: "Bitbake Build"
+                    stage('Bitbake Build') {
+                        if (is_pr) {
+                            setGitHubPullRequestStatus state: 'PENDING', context: "${env.JOB_NAME}", message: "Bitbake Build"
+                        }
+                        params = ["${script_env}",
+                        "docker/build-project.sh"].join("\n")
+                        sh "${params}"
                     }
-                    params = ["${script_env}",
-                    "docker/build-project.sh"].join("\n")
-                    sh "${params}"
-
-                    stage "Build publishing"
-                    if (is_pr) {
-                        setGitHubPullRequestStatus state: 'PENDING', context: "${env.JOB_NAME}", message: "Build publishing"
+                    stage('Build publishing') {
+                        if (is_pr) {
+                            setGitHubPullRequestStatus state: 'PENDING', context: "${env.JOB_NAME}", message: "Build publishing"
+                        }
+                        params =  ["${script_env}",
+                        "docker/publish-project.sh"].join("\n")
+                        sh "${params}"
                     }
-                    params =  ["${script_env}",
-                    "docker/publish-project.sh"].join("\n")
-                    sh "${params}"
                 }
             } // sshagent
             } // timestamps
@@ -186,9 +184,10 @@ try {
             }
         }
     }
-    stage "Parallel test run"
-    timestamps {
-        parallel test_runs
+    stage('Parallel test run') {
+        timestamps {
+            parallel test_runs
+        }
     }
 
     if (is_pr) {

--- a/docker/local-build.sh
+++ b/docker/local-build.sh
@@ -19,11 +19,15 @@ RUN_ARGS=(-u "`id -u`")
 safe_proxy_vars="HTTP_PROXY http_proxy HTTPS_PROXY https_proxy FTP_PROXY ftp_proxy NO_PROXY no_proxy ALL_PROXY socks_proxy SOCKS_PROXY"
 
 for proxy in $safe_proxy_vars; do
-    if [ -v $proxy ]; then
+    # Use variable only if value defined.
+    # Note that this is different thing from variable defined empty
+    # Avoid use bash-specific [ -v var ] for portability
+    if [ "$(env|grep $proxy)" != "" ]; then
+        eval _proxyval=\$$proxy
         # strip spaces from values, if any.
-        val="`echo ${!proxy} | tr -d ' '`"
+        val="`echo ${_proxyval} | tr -d ' '`"
         BUILD_ARGS="$BUILD_ARGS --build-arg $proxy=${val}"
-        RUN_ARGS+=(-e "$proxy=${!proxy}")
+        RUN_ARGS+=(-e "$proxy=${_proxyval}")
     fi
 done
 

--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -113,7 +113,7 @@ if [ -f "${LOG}" ]; then
 fi
 
 if [ -d sstate-cache ]; then
-  if [ -v BUILD_CACHE_DIR ]; then
+  if [ ! -z ${BUILD_CACHE_DIR+x} ]; then
     if [ -d ${BUILD_CACHE_DIR}/sstate ]; then
       # populate shared sstate from local sstate:
       _src=sstate-cache

--- a/docker/tester-exec.sh
+++ b/docker/tester-exec.sh
@@ -79,9 +79,9 @@ testimg() {
     set -e
   fi
 
-  if [ -v TEST_DEVICE ]; then
+  if [ ! -z ${TEST_DEVICE+x} ]; then
     DEVICE="$TEST_DEVICE"
-  elif [ -v JOB_NAME ]; then
+  elif [ ! -z ${JOB_NAME+x} ]; then
     DEVICE=`echo ${JOB_NAME} | awk -F'_' '{print $2}'`
   else
     DEVICE="unconfigured"


### PR DESCRIPTION
We used some bash-specific is-var-defined testing via -v VAR
which does not work in older bash and in other shells,
also indirect use of variable name as variable is bash-specific
so the code is changed to avoid these specific features.
Functionally should be equal to previous state of scripts.
