### PR TITLE
CI Jenkinsfile: Examine build result before setting GH status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,11 @@ try {
     }
 
     if (is_pr) {
-        setGitHubPullRequestStatus state: 'SUCCESS', context: "${env.JOB_NAME}", message: 'Build finished successfuly'
+        if (currentBuild.result == 'SUCCESS') {
+            setGitHubPullRequestStatus state: 'SUCCESS', context: "${env.JOB_NAME}", message: 'Build finished successfully'
+        } else {
+            setGitHubPullRequestStatus state: 'FAILURE', context: "${env.JOB_NAME}", message: "Build failed"
+        }
     }
 } catch (Exception e) {
     echo "Error: ${e}"


### PR DESCRIPTION
If CI build result is set to failed in Xunit processing,
we dont get Exception called, and we report SUCCESS to GH PR status.
To avoid such mistake, we examine job result before reporting.
Job result reflects the correct value at that point.
This fixes issue #47
