### PR TITLE
CI Jenkinsfile: stop cleaning old build dir as build stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,11 +73,6 @@ try {
                 checkout poll: false, scm: scm
             }
 
-            stage 'Cleanup old build directory'
-            dir('build') {
-                deleteDir()
-            }
-
             stage 'Build docker image'
             if (is_pr) {
                 setGitHubPullRequestStatus state: 'PENDING', context: "${env.JOB_NAME}", message: "Building Docker image"


### PR DESCRIPTION
As all workspace is cleaned as 1st stage, the build dir
in workspace is already always empty, stop cleaning
it and showing that as (very short) build stage.
2nd commit here rewrites stage() blocks to match the
recently changed pipeline plugin syntax: needs stage sentences in a {} block
