### PR TITLE
Do not enable autosuspend on USB HID devices

### DIFF
--- a/meta-ostro-xt/recipes-bsp/joule-udev-rules/files/usb-power.rules
+++ b/meta-ostro-xt/recipes-bsp/joule-udev-rules/files/usb-power.rules
@@ -9,7 +9,7 @@
 ACTION=="add", SUBSYSTEMS=="usb", PROGRAM="/bin/sh -c 'grep -q ^$attr{idVendor}:$attr{idProduct} /lib/udev/usb-autosuspend-blacklist || ( [ -e /etc/udev/usb-autosuspend-blacklist ] && grep -q $attr{idVendor}:$attr{idProduct} /etc/udev/usb-autosuspend-blacklist)'", GOTO="power_usb_rules_end"
 
 # Enable autosuspend.
-ACTION=="add", SUBSYSTEMS=="usb", TEST=="power/control", ATTR{power/control}="auto"
+ACTION=="add", SUBSYSTEMS=="usb", ENV{INTERFACE}!="3/*, TEST=="power/control", ATTR{power/control}="auto"
 
 # Done.
 LABEL="power_usb_rules_end"


### PR DESCRIPTION
If HID devices are suspended, they don't necessarily wake up when used,
so avoid attempting autosuspend on HID devices to keep the device usable
when USB HID devices are connected.

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
