### PR TITLE
Jenkinsfile: add try-catch-finally block around tester-exec call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,19 +147,23 @@ try {
                 writeFile file: 'testinfo.csv', text: testinfo_data
 
                 def ci_build_id = "${env.BUILD_TIMESTAMP}-build-${env.BUILD_NUMBER}"
-                withEnv(["CI_BUILD_ID=${ci_build_id}",
-                         "CI_BUILD_URL=${env.COORD_BASE_URL}/builds/${env.JOB_NAME}/${ci_build_id}",
-                         "MACHINE=${target_machine}",
-                         "TEST_DEVICE=${test_device}" ]){
-                    sh 'env && chmod a+x tester-exec.sh && ./tester-exec.sh'
+                try {
+                    withEnv(["CI_BUILD_ID=${ci_build_id}",
+                             "CI_BUILD_URL=${env.COORD_BASE_URL}/builds/${env.JOB_NAME}/${ci_build_id}",
+                             "MACHINE=${target_machine}",
+                             "TEST_DEVICE=${test_device}" ]){
+                        sh 'env && chmod a+x tester-exec.sh && ./tester-exec.sh'
+                    }
+                } catch (Exception e) {
+                    throw e
+                } finally {
+                    sh "sed -e 's/name=\"oeqa/name=\"${test_device}.oeqa/g' -i TEST-*.xml"
+                    sh "rename TEST- TEST-${test_device}- TEST-*.xml"
+                    sh "rename aft- aft-${test_device} aft-*"
+                    sh "rename .log .${test_device}.log *.log"
+
+                    archive '**/*.log, **/*.xml, **/aft-results-*.tar.bz2'
                 }
-
-                sh "sed -e 's/name=\"oeqa/name=\"${test_device}.oeqa/g' -i TEST-*.xml"
-                sh "rename TEST- TEST-${test_device}- TEST-*.xml"
-                sh "rename aft- aft-${test_device} aft-*"
-                sh "rename .log .${test_device}.log *.log"
-
-                archive '**/*.log, **/*.xml, **/aft-results-*.tar.bz2'
 
                 step([$class: 'XUnitPublisher',
                     testTimeMargin: '3000',


### PR DESCRIPTION
XT flow has been different from Ostro CI main jobs flow
where tester results (like logs) are archived in post-build
step, making them available even if tester (AFT) failed.
This was not case in XT script which did not archive logs
because failed tester-exec.sh did not make any after-steps.
This change tries to achieve after-step via try-finally construct.