### PR TITLE
Update kernel to latest HEAD

### DIFF
--- a/meta-ostro-xt/recipes-kernel/linux/linux-yocto_4.4.bbappend
+++ b/meta-ostro-xt/recipes-kernel/linux/linux-yocto_4.4.bbappend
@@ -3,12 +3,12 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_prepend_intel-corei7-64 = "file://fix_branch.scc "
 SRC_URI_append_intel-corei7-64 = " file://disable-iwlwifi-upstream.cfg"
 
-LINUX_VERSION_INTEL_COMMON_forcevariable = "4.4.26"
+LINUX_VERSION_INTEL_COMMON_forcevariable = "4.4.32"
 KBRANCH_corei7-64-intel-common_forcevariable = "standard/intel/bxt-rebase;rebaseable=1"
 # http://git.yoctoproject.org/cgit/cgit.cgi/linux-yocto-4.4/log/?h=standard/intel/bxt-rebase
-SRCREV_machine_corei7-64-intel-common = "b7ddcae5f0f374ab7ffd49b0f8636328f5e3386f"
+SRCREV_machine_corei7-64-intel-common = "14ed59a239de7c119592c29503b82efc56ad0697"
 # http://git.yoctoproject.org/cgit/cgit.cgi/yocto-kernel-cache/log/?h=yocto-4.4
-SRCREV_meta_corei7-64-intel-common = "3030330b066a33ce21164a8b30d0503cf9f68e5b"
+SRCREV_meta_corei7-64-intel-common = "24ea5324fc90c7cb15ce1a08cdd294f22c6e6382"
 
 # This feature was already removed from KERNEL_FEATURES_INTEL_COMMON
 # in meta-intel master (a4c1cfb53d192, linux-yocto*: remove mei from


### PR DESCRIPTION
Updates kernel to 4.4.32 level.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>