### PR TITLE
Jenkinsfile: set allowed test failure thresholds to zero

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,8 +174,8 @@ try {
                     thresholdMode: 1,
                     thresholds: [
                         [$class: 'FailedThreshold',
-                            failureNewThreshold: '3',
-                            failureThreshold: '15',
+                            failureNewThreshold: '0',
+                            failureThreshold: '0',
                             unstableNewThreshold: '99999',
                             unstableThreshold: '99999'],
                         [$class: 'SkippedThreshold',


### PR DESCRIPTION
Any other value has risk letting failures through without
noticing. Not clear why there was anything else than zero,
early dev-phase relaxation forgotten to remove?