### PR TITLE
python: CVE-2016-5636

### DIFF
--- a/meta-ostro-xt/recipes-devtools/python/python/CVE-2016-5636.patch
+++ b/meta-ostro-xt/recipes-devtools/python/python/CVE-2016-5636.patch
@@ -1,0 +1,44 @@
+
+# HG changeset patch
+# User Benjamin Peterson <benjamin@python.org>
+# Date 1453357424 28800
+# Node ID 985fc64c60d6adffd1138b6cc46df388ca91ca5d
+# Parent  7ec954b9fc54448a35b56d271340ba109eb381b9
+prevent buffer overflow in get_data (closes #26171)
+
+Upstream-Status: Backport
+https://hg.python.org/cpython/rev/985fc64c60d6
+
+CVE: CVE-2016-5636
+Signed-off-by: Armin Kuster <akuster@mvista.com>
+
+Index: Python-2.7.11/Misc/NEWS
+===================================================================
+--- Python-2.7.11.orig/Misc/NEWS
++++ Python-2.7.11/Misc/NEWS
+@@ -7,6 +7,9 @@ What's New in Python 2.7.11?
+ 
+ *Release date: 2015-12-05*
+ 
++- Issue #26171: Fix possible integer overflow and heap corruption in
++  zipimporter.get_data().
++
+ Library
+ -------
+ 
+Index: Python-2.7.11/Modules/zipimport.c
+===================================================================
+--- Python-2.7.11.orig/Modules/zipimport.c
++++ Python-2.7.11/Modules/zipimport.c
+@@ -895,6 +895,11 @@ get_data(char *archive, PyObject *toc_en
+         PyMarshal_ReadShortFromFile(fp);        /* local header size */
+     file_offset += l;           /* Start of file data */
+ 
++    if (data_size > LONG_MAX - 1) {
++        fclose(fp);
++        PyErr_NoMemory();
++        return NULL;
++    }
+     raw_data = PyString_FromStringAndSize((char *)NULL, compress == 0 ?
+                                           data_size : data_size + 1);
+     if (raw_data == NULL) {

--- a/meta-ostro-xt/recipes-devtools/python/python3/CVE-2016-5636.patch
+++ b/meta-ostro-xt/recipes-devtools/python/python3/CVE-2016-5636.patch
@@ -1,0 +1,44 @@
+
+# HG changeset patch
+# User Benjamin Peterson <benjamin@python.org>
+# Date 1453357506 28800
+# Node ID 10dad6da1b28ea4af78ad9529e469fdbf4ebbc8f
+# Parent  a3ac2cd93db9d5336dfd7b5b27efde2c568d8794# Parent  01ddd608b85c85952537d95a43bbabf4fb655057
+merge 3.4 (#26171)
+
+Upstream-Status: Backport
+CVE: CVE-2016-5636
+
+https://hg.python.org/cpython/raw-rev/10dad6da1b28
+Signed-off-by: Armin Kuster <akuster@mvista.com>
+
+Index: Python-3.5.1/Misc/NEWS
+===================================================================
+--- Python-3.5.1.orig/Misc/NEWS
++++ Python-3.5.1/Misc/NEWS
+@@ -91,6 +91,9 @@ Core and Builtins
+   Python.h header to fix a compilation error with OpenMP. PyThreadState_GET()
+   becomes an alias to PyThreadState_Get() to avoid ABI incompatibilies.
+ 
++- Issue #26171: Fix possible integer overflow and heap corruption in
++  zipimporter.get_data().
++
+ Library
+ -------
+ 
+Index: Python-3.5.1/Modules/zipimport.c
+===================================================================
+--- Python-3.5.1.orig/Modules/zipimport.c
++++ Python-3.5.1/Modules/zipimport.c
+@@ -1112,6 +1112,11 @@ get_data(PyObject *archive, PyObject *to
+     }
+     file_offset += l;           /* Start of file data */
+ 
++    if (data_size > LONG_MAX - 1) {
++        fclose(fp);
++        PyErr_NoMemory();
++        return NULL;
++    }
+     bytes_size = compress == 0 ? data_size : data_size + 1;
+     if (bytes_size == 0)
+         bytes_size++;

--- a/meta-ostro-xt/recipes-devtools/python/python3_3.5.1.bbappend
+++ b/meta-ostro-xt/recipes-devtools/python/python3_3.5.1.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/python3:"
+
+SRC_URI_append = " file://CVE-2016-5636.patch"

--- a/meta-ostro-xt/recipes-devtools/python/python_2.7.11.bbappend
+++ b/meta-ostro-xt/recipes-devtools/python/python_2.7.11.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/python:"
+
+SRC_URI_append = " file://CVE-2016-5636.patch"


### PR DESCRIPTION
Fix integer overflow and heap corruption in Python's zipimporter.get_data(). The patch is backported from https://patchwork.openembedded.org/patch/127355/ and https://patchwork.openembedded.org/patch/127357/ .
