### PR TITLE
CI publish-project.sh include symlinks when syncing detailed logs

### DIFF
--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -133,8 +133,10 @@ if [ -d ${_BRESULT}/buildstats ]; then
     rsync --stats -a ${_BRESULT}/buildstats/* ${_RSYNC_DEST}/.buildstats/${TARGET_MACHINE}/
 fi
 # Copy detailed build logs
+# Include symlinks to avoid massive amount of "skipping non-regular file"
+# lines in the rsyncd server system-level log
 create_remote_dirs ${_RSYNC_DEST} detailed-logs/${TARGET_MACHINE}/
-rsync -qzr --prune-empty-dirs --include "log.*" --include "*/" --exclude "*" ${_BRESULT}/work*/* ${_RSYNC_DEST}/detailed-logs/${TARGET_MACHINE}/
+rsync -qzrl --prune-empty-dirs --include "log.*" --include "*/" --exclude "*" ${_BRESULT}/work*/* ${_RSYNC_DEST}/detailed-logs/${TARGET_MACHINE}/
 
 # Create latest symlink locally and rsync it to parent dir of publish dir
 ln -vsf ${CI_BUILD_ID} latest


### PR DESCRIPTION
We used to exclude symlinks to log files as not really needed,
but this creates massive amount of messages on server rsyncd
"skipping non-regular file" which are hard to turn off
from client (no easy way to just skip symlinks sending).
So let's send symlinks, it's smaller overhead than creating
all those log lines in server system-level log.